### PR TITLE
Improve test coverage

### DIFF
--- a/__tests__/main/slices/recordingSlice.test.ts
+++ b/__tests__/main/slices/recordingSlice.test.ts
@@ -2,12 +2,11 @@ import recordingReducer, {
   updateConnectionStatus,
   setRecordingError,
 } from '../../../src/main/store/slices/recordingSlice';
-
 import type { RecordingState } from '../../../src/types/redux';
 
 describe('recordingSlice reducer', () => {
   const getInitialState = (): RecordingState =>
-    recordingReducer(undefined, { type: 'unknown' }) as RecordingState;
+    recordingReducer(undefined, { type: 'unknown' });
 
   it('should clear error when both streams connected', () => {
     // start with error state

--- a/__tests__/main/slices/recordingSlice.test.ts
+++ b/__tests__/main/slices/recordingSlice.test.ts
@@ -1,0 +1,48 @@
+import recordingReducer, {
+  updateConnectionStatus,
+  setRecordingError,
+} from '../../../src/main/store/slices/recordingSlice';
+
+import type { RecordingState } from '../../../src/types/redux';
+
+describe('recordingSlice reducer', () => {
+  const getInitialState = (): RecordingState =>
+    recordingReducer(undefined, { type: 'unknown' }) as RecordingState;
+
+  it('should clear error when both streams connected', () => {
+    // start with error state
+    let state: RecordingState = {
+      ...getInitialState(),
+      error: 'microphone disconnected',
+    };
+
+    // Connect microphone only
+    state = recordingReducer(
+      state,
+      updateConnectionStatus({ stream: 'microphone', connected: true })
+    );
+    // Error should persist because system still false
+    expect(state.error).toBe('microphone disconnected');
+
+    // Connect system stream
+    state = recordingReducer(
+      state,
+      updateConnectionStatus({ stream: 'system', connected: true })
+    );
+
+    // Now both connected, error should be cleared
+    expect(state.connectionStatus.microphone).toBe(true);
+    expect(state.connectionStatus.system).toBe(true);
+    expect(state.error).toBeNull();
+  });
+
+  it('setRecordingError should set status to error and assign message', () => {
+    const state = recordingReducer(
+      getInitialState(),
+      setRecordingError('Something went wrong')
+    );
+
+    expect(state.status).toBe('error');
+    expect(state.error).toBe('Something went wrong');
+  });
+});

--- a/__tests__/main/slices/settingsSlice.test.ts
+++ b/__tests__/main/slices/settingsSlice.test.ts
@@ -1,0 +1,51 @@
+import settingsReducer, {
+  updateSettings,
+  setAssemblyAIKey,
+  setSlackBotToken,
+  setSlackChannels,
+} from '../../../src/main/store/slices/settingsSlice';
+
+import type { SettingsState } from '../../../src/types/index';
+
+describe('settingsSlice reducer', () => {
+  const getInitialState = (): SettingsState =>
+    settingsReducer(undefined, { type: 'unknown' }) as SettingsState;
+
+  it('should update computed properties via updateSettings', () => {
+    const prevState = getInitialState();
+
+    const updatedState = settingsReducer(
+      prevState,
+      updateSettings({
+        assemblyaiKey: 'key-123',
+        slackBotToken: 'xoxb-token',
+        slackChannels: 'C1234,C4321',
+      })
+    );
+
+    expect(updatedState.assemblyaiKey).toBe('key-123');
+    expect(updatedState.hasAssemblyAIKey).toBe(true);
+
+    expect(updatedState.slackBotToken).toBe('xoxb-token');
+    expect(updatedState.hasSlackBotToken).toBe(true);
+
+    expect(updatedState.slackChannels).toBe('C1234,C4321');
+    expect(updatedState.hasSlackChannels).toBe(true);
+  });
+
+  it('should set individual keys and maintain computed props', () => {
+    let state = getInitialState();
+
+    state = settingsReducer(state, setAssemblyAIKey('api-key'));
+    expect(state.assemblyaiKey).toBe('api-key');
+    expect(state.hasAssemblyAIKey).toBe(true);
+
+    state = settingsReducer(state, setSlackBotToken(''));
+    expect(state.slackBotToken).toBe('');
+    expect(state.hasSlackBotToken).toBe(false);
+
+    state = settingsReducer(state, setSlackChannels('CHANNEL1'));
+    expect(state.slackChannels).toBe('CHANNEL1');
+    expect(state.hasSlackChannels).toBe(true);
+  });
+});

--- a/__tests__/main/slices/settingsSlice.test.ts
+++ b/__tests__/main/slices/settingsSlice.test.ts
@@ -4,12 +4,11 @@ import settingsReducer, {
   setSlackBotToken,
   setSlackChannels,
 } from '../../../src/main/store/slices/settingsSlice';
-
 import type { SettingsState } from '../../../src/types/index';
 
 describe('settingsSlice reducer', () => {
   const getInitialState = (): SettingsState =>
-    settingsReducer(undefined, { type: 'unknown' }) as SettingsState;
+    settingsReducer(undefined, { type: 'unknown' });
 
   it('should update computed properties via updateSettings', () => {
     const prevState = getInitialState();

--- a/__tests__/main/slices/transcriptionSlice.test.ts
+++ b/__tests__/main/slices/transcriptionSlice.test.ts
@@ -1,0 +1,79 @@
+import transcriptionReducer, {
+  addTranscriptSegment,
+  updateTranscriptBuffer,
+  clearTranscription,
+} from '../../../src/main/store/slices/transcriptionSlice';
+
+import type { TranscriptionState, TranscriptSegment } from '../../../src/types/redux';
+
+describe('transcriptionSlice reducer', () => {
+  const getInitialState = (): TranscriptionState =>
+    transcriptionReducer(undefined, { type: 'unknown' }) as TranscriptionState;
+
+  it('should build currentTranscript from final segments', () => {
+    const segment1: TranscriptSegment = {
+      text: 'Hello',
+      isFinal: true,
+      timestamp: 0,
+      source: 'microphone',
+    };
+
+    const segment2: TranscriptSegment = {
+      text: 'world',
+      isFinal: true,
+      timestamp: 1,
+      source: 'microphone',
+    };
+
+    let state = getInitialState();
+
+    state = transcriptionReducer(state, addTranscriptSegment(segment1));
+    expect(state.currentTranscript).toBe('Hello');
+
+    state = transcriptionReducer(state, addTranscriptSegment(segment2));
+    expect(state.currentTranscript).toBe('Hello world');
+  });
+
+  it('should update transcript buffers independently', () => {
+    let state = getInitialState();
+
+    state = transcriptionReducer(
+      state,
+      updateTranscriptBuffer({ source: 'microphone', text: 'mic text' })
+    );
+    expect(state.microphoneTranscriptBuffer).toBe('mic text');
+    expect(state.systemAudioTranscriptBuffer).toBe('');
+
+    state = transcriptionReducer(
+      state,
+      updateTranscriptBuffer({ source: 'system', text: 'sys text' })
+    );
+    expect(state.systemAudioTranscriptBuffer).toBe('sys text');
+  });
+
+  it('clearTranscription should reset relevant fields', () => {
+    let state: TranscriptionState = {
+      ...getInitialState(),
+      currentTranscript: 'some text',
+      microphoneTranscriptBuffer: 'buf',
+      systemAudioTranscriptBuffer: 'buf2',
+      segments: [
+        {
+          text: 'temp',
+          isFinal: false,
+          timestamp: 0,
+          source: 'microphone',
+        },
+      ],
+      error: 'oops',
+    };
+
+    state = transcriptionReducer(state, clearTranscription());
+
+    expect(state.currentTranscript).toBe('');
+    expect(state.segments).toHaveLength(0);
+    expect(state.microphoneTranscriptBuffer).toBe('');
+    expect(state.systemAudioTranscriptBuffer).toBe('');
+    expect(state.error).toBeNull();
+  });
+});

--- a/__tests__/main/slices/transcriptionSlice.test.ts
+++ b/__tests__/main/slices/transcriptionSlice.test.ts
@@ -3,12 +3,14 @@ import transcriptionReducer, {
   updateTranscriptBuffer,
   clearTranscription,
 } from '../../../src/main/store/slices/transcriptionSlice';
-
-import type { TranscriptionState, TranscriptSegment } from '../../../src/types/redux';
+import type {
+  TranscriptionState,
+  TranscriptSegment,
+} from '../../../src/types/redux';
 
 describe('transcriptionSlice reducer', () => {
   const getInitialState = (): TranscriptionState =>
-    transcriptionReducer(undefined, { type: 'unknown' }) as TranscriptionState;
+    transcriptionReducer(undefined, { type: 'unknown' });
 
   it('should build currentTranscript from final segments', () => {
     const segment1: TranscriptSegment = {


### PR DESCRIPTION
Add unit tests for `settingsSlice`, `recordingSlice`, and `transcriptionSlice` to improve test coverage and validate reducer behaviors.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1a10e0b-0a40-4ccc-a58c-cbc3ccf4a353">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b1a10e0b-0a40-4ccc-a58c-cbc3ccf4a353">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>